### PR TITLE
Pin s3fs version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     'aind-data-schema',
     'pandas',
     'plotly',
-    's3fs',
+    's3fs==2024.12.0',
     'graphviz',
     'nbformat==5.1.2',
     'matplotlib',


### PR DESCRIPTION
There seemed to be a break change in `s3fs` where `fs.get` no longer returns the number of objects, but rather returns a None, which breaks this line

https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training/blob/8b1714405a831b94b837e5f3ee99ea560f315c0d/code/aind_auto_train/util/aws_util.py#L77-L79

and causes a bug in ForagingGUI reported by Nathan on rig W10DT714693

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/3372b3b2-1785-4fb9-bf26-31d51c7a4c5d" />
